### PR TITLE
Extract methods from MSS---Machine Shop Simulator 

### DIFF
--- a/src/applications/Job.java
+++ b/src/applications/Job.java
@@ -50,4 +50,29 @@ class Job {
         return id;
     }
 
+	/**
+	 * move theJob to machine for its next task
+	 * 
+	 * @param machineShopSimulator TODO
+	 * @param simulationResults TODO
+	 * @return false iff no next task
+	 */
+	boolean moveToNextMachine(MachineShopSimulator machineShopSimulator, SimulationResults simulationResults) {
+	    if (getTaskQ().isEmpty()) {// no next task
+	        simulationResults.setJobCompletionData(getId(), machineShopSimulator.timeNow, machineShopSimulator.timeNow - getLength());
+	        return false;
+	    } else {// theJob has a next task
+	            // get machine for next task
+	        int p = ((Task) getTaskQ().getFrontElement()).getMachine();
+	        // put on machine p's wait queue
+	        machineShopSimulator.machine[p].getJobQ().put(this);
+	        setArrivalTime(machineShopSimulator.timeNow);
+	        // if p idle, schedule immediately
+	        if (machineShopSimulator.eList.nextEventTime(p) == machineShopSimulator.largeTime) {// machine is idle
+	            machineShopSimulator.changeState(p);
+	        }
+	        return true;
+	    }
+	}
+
 }

--- a/src/applications/MachineShopSimulator.java
+++ b/src/applications/MachineShopSimulator.java
@@ -11,36 +11,12 @@ public class MachineShopSimulator {
     public static final String BAD_MACHINE_NUMBER_OR_TASK_TIME = "bad machine number or task time";
 
     // data members of MachineShopSimulator
-    private int timeNow; // current time
+    int timeNow; // current time
     private int numMachines; // number of machines
     private int numJobs; // number of jobs
-    private EventList eList; // pointer to event list
+    EventList eList; // pointer to event list
     public Machine[] machine; // array of machines
-    private int largeTime; // all machines finish before this
-
-    // methods
-    /**
-     * move theJob to machine for its next task
-     * 
-     * @return false iff no next task
-     */
-    boolean moveToNextMachine(Job theJob, SimulationResults simulationResults) {
-        if (theJob.getTaskQ().isEmpty()) {// no next task
-            simulationResults.setJobCompletionData(theJob.getId(), timeNow, timeNow - theJob.getLength());
-            return false;
-        } else {// theJob has a next task
-                // get machine for next task
-            int p = ((Task) theJob.getTaskQ().getFrontElement()).getMachine();
-            // put on machine p's wait queue
-            machine[p].getJobQ().put(theJob);
-            theJob.setArrivalTime(timeNow);
-            // if p idle, schedule immediately
-            if (eList.nextEventTime(p) == largeTime) {// machine is idle
-                changeState(p);
-            }
-            return true;
-        }
-    }
+    int largeTime; // all machines finish before this
 
     /**
      * change the state of theMachine
@@ -112,7 +88,7 @@ public class MachineShopSimulator {
             Job theJob = changeState(nextToFinish);
             // move theJob to its next machine
             // decrement numJobs if theJob has finished
-            if (theJob != null && !moveToNextMachine(theJob, simulationResults))
+            if (theJob != null && !theJob.moveToNextMachine(this, simulationResults))
                 numJobs--;
         }
     }

--- a/src/applications/MachineShopSimulator.java
+++ b/src/applications/MachineShopSimulator.java
@@ -15,7 +15,7 @@ public class MachineShopSimulator {
     private int numMachines; // number of machines
     private int numJobs; // number of jobs
     private EventList eList; // pointer to event list
-    private Machine[] machine; // array of machines
+    public Machine[] machine; // array of machines
     private int largeTime; // all machines finish before this
 
     // methods
@@ -76,12 +76,6 @@ public class MachineShopSimulator {
         return lastJob;
     }
 
-    private void setMachineChangeOverTimes(SimulationSpecification specification) {
-        for (int i = 1; i<=specification.getNumMachines(); ++i) {
-            machine[i].setChangeTime(specification.getChangeOverTimes(i));
-        }
-    }
-
     private void setUpJobs(SimulationSpecification specification) {
         // input the jobs
         Job theJob;
@@ -119,7 +113,7 @@ public class MachineShopSimulator {
         createEventAndMachineQueues(specification);
 
         // Move this to startShop when ready
-        setMachineChangeOverTimes(specification);
+        specification.setMachineChangeOverTimes(this);
 
         // Move this to startShop when ready
         setUpJobs(specification);

--- a/src/applications/MachineShopSimulator.java
+++ b/src/applications/MachineShopSimulator.java
@@ -76,26 +76,6 @@ public class MachineShopSimulator {
         return lastJob;
     }
 
-    private void setUpJobs(SimulationSpecification specification) {
-        // input the jobs
-        Job theJob;
-        for (int i = 1; i <= specification.getNumJobs(); i++) {
-            int tasks = specification.getJobSpecifications(i).getNumTasks();
-            int firstMachine = 0; // machine for first task
-
-            // create the job
-            theJob = new Job(i);
-            for (int j = 1; j <= tasks; j++) {
-                int theMachine = specification.getJobSpecifications(i).getSpecificationsForTasks()[2*(j-1)+1];
-                int theTaskTime = specification.getJobSpecifications(i).getSpecificationsForTasks()[2*(j-1)+2];
-                if (j == 1)
-                    firstMachine = theMachine; // job's first machine
-                theJob.addTask(theMachine, theTaskTime); // add to
-            } // task queue
-            machine[firstMachine].getJobQ().put(theJob);
-        }
-    }
-
     private void createEventAndMachineQueues(SimulationSpecification specification) {
         // create event and machine queues
         eList = new EventList(specification.getNumMachines(), largeTime);
@@ -116,7 +96,7 @@ public class MachineShopSimulator {
         specification.setMachineChangeOverTimes(this);
 
         // Move this to startShop when ready
-        setUpJobs(specification);
+        specification.setUpJobs(this);
 
         for (int p = 1; p <= numMachines; p++)
             changeState(p);

--- a/src/applications/MachineShopSimulator.java
+++ b/src/applications/MachineShopSimulator.java
@@ -52,21 +52,13 @@ public class MachineShopSimulator {
         return lastJob;
     }
 
-    private void createEventAndMachineQueues(SimulationSpecification specification) {
-        // create event and machine queues
-        eList = new EventList(specification.getNumMachines(), largeTime);
-        machine = new Machine[specification.getNumMachines() + 1];
-        for (int i = 1; i <= specification.getNumMachines(); i++)
-            machine[i] = new Machine();
-    }
-
     /** load first jobs onto each machine
      * @param specification*/
     void startShop(SimulationSpecification specification) {
         // Move this to startShop when ready
         numMachines = specification.getNumMachines();
         numJobs = specification.getNumJobs();
-        createEventAndMachineQueues(specification);
+        specification.createEventAndMachineQueues(this);
 
         // Move this to startShop when ready
         specification.setMachineChangeOverTimes(this);

--- a/src/applications/SimulationSpecification.java
+++ b/src/applications/SimulationSpecification.java
@@ -84,4 +84,12 @@ public class SimulationSpecification {
 	        machineShopSimulator.machine[firstMachine].getJobQ().put(theJob);
 	    }
 	}
+
+	void createEventAndMachineQueues(MachineShopSimulator machineShopSimulator) {
+	    // create event and machine queues
+	    machineShopSimulator.eList = new EventList(getNumMachines(), machineShopSimulator.largeTime);
+	    machineShopSimulator.machine = new Machine[getNumMachines() + 1];
+	    for (int i = 1; i <= getNumMachines(); i++)
+	        machineShopSimulator.machine[i] = new Machine();
+	}
 }

--- a/src/applications/SimulationSpecification.java
+++ b/src/applications/SimulationSpecification.java
@@ -58,4 +58,10 @@ public class SimulationSpecification {
         builder.append(">");
         return builder.toString();
     }
+
+	public void setMachineChangeOverTimes(MachineShopSimulator machineShopSimulator) {
+	    for (int i = 1; i<=getNumMachines(); ++i) {
+	        machineShopSimulator.machine[i].setChangeTime(getChangeOverTimes(i));
+	    }
+	}
 }

--- a/src/applications/SimulationSpecification.java
+++ b/src/applications/SimulationSpecification.java
@@ -64,4 +64,24 @@ public class SimulationSpecification {
 	        machineShopSimulator.machine[i].setChangeTime(getChangeOverTimes(i));
 	    }
 	}
+
+	void setUpJobs(MachineShopSimulator machineShopSimulator) {
+	    // input the jobs
+	    Job theJob;
+	    for (int i = 1; i <= getNumJobs(); i++) {
+	        int tasks = getJobSpecifications(i).getNumTasks();
+	        int firstMachine = 0; // machine for first task
+	
+	        // create the job
+	        theJob = new Job(i);
+	        for (int j = 1; j <= tasks; j++) {
+	            int theMachine = getJobSpecifications(i).getSpecificationsForTasks()[2*(j-1)+1];
+	            int theTaskTime = getJobSpecifications(i).getSpecificationsForTasks()[2*(j-1)+2];
+	            if (j == 1)
+	                firstMachine = theMachine; // job's first machine
+	            theJob.addTask(theMachine, theTaskTime); // add to
+	        } // task queue
+	        machineShopSimulator.machine[firstMachine].getJobQ().put(theJob);
+	    }
+	}
 }


### PR DESCRIPTION
# Problem:
MSS had several method clustering up the class that would greatly improve readability and organization of the code if they were moved to different classes that better supported them being there
# Solution:
We extracted most methods to `SimulationSpecification` since we were calling that class and it would be simpler to just have them in that class instead. One method was also moved to `Jobs.java`  for similar reasons. For the most part all extraction went smoothly and did not have any conflicting issues that caused test to fail. All test are passing. 
It is important to note that these changes are more foundational and these methods will see more changes again, but for this pull request it was felt in order to maintain simplicity those changes would come at a later time.
# Changes:
These were the following methods extracted to `SimulationSpecification`:
`createEventAndMachineQueues`
`setUpJobs`
`setMachineChangeOverTimes`

`moveToNextMachine` was extracted to `Job`


Other than extracting the only major change was `Machine [] machine` was given the attribute `public` so it could be access outside of MSS. 